### PR TITLE
feat: show actual request details in vendor test dialog

### DIFF
--- a/frontend/src/api/vendor.ts
+++ b/frontend/src/api/vendor.ts
@@ -10,6 +10,9 @@ export interface VendorTestResponse {
     url?: string;
     converted_from?: string;
     converted_to?: string;
+    request_method?: string;
+    request_headers?: Record<string, string>;
+    request_body?: unknown;
     response?: unknown;
     error?: unknown;
 }

--- a/frontend/src/views/Vendor/DialogTest.vue
+++ b/frontend/src/views/Vendor/DialogTest.vue
@@ -116,6 +116,21 @@
                     </a-space>
                 </div>
 
+                <div v-if="result.request_headers || result.request_body" class="result-detail">
+                    <div class="detail-label">
+                        请求原文:
+                        <a-button
+                            type="link"
+                            size="small"
+                            class="copy-btn"
+                            @click="copyRequestText"
+                        >
+                            <CopyOutlined /> 复制
+                        </a-button>
+                    </div>
+                    <pre class="request-body">{{ formattedRequest }}</pre>
+                </div>
+
                 <div class="result-detail">
                     <div class="detail-label">响应详情:</div>
                     <pre class="response-body">{{ formattedResponse }}</pre>
@@ -131,6 +146,8 @@ import { testVendor, listVendorModels } from '@/api/vendor';
 import type { VendorTestResponse } from '@/api/vendor';
 import type { Vendor, VendorModel } from '@/types/vendor';
 import { notifyRequestError, notifySuccess, notifyWarning } from '@/utils/requestFeedback';
+import { message as antMessage } from 'ant-design-vue';
+import { CopyOutlined } from '@ant-design/icons-vue';
 import { useVendorPresets } from '@/composables/useVendorPresets';
 
 interface ModelInfo {
@@ -247,6 +264,46 @@ const formattedResponse = computed(() => {
         return String(data);
     }
 });
+
+
+const formattedRequest = computed(() => {
+    const r = result.value;
+    if (!r) return '';
+    const method = r.request_method || 'POST';
+    const url = r.url || '';
+    const headers = r.request_headers || {};
+    const body = r.request_body;
+
+    const lines: string[] = [];
+    lines.push(`${method} ${url}`);
+    for (const [key, value] of Object.entries(headers)) {
+        lines.push(`${key}: ${value}`);
+    }
+    if (body !== undefined && body !== null) {
+        lines.push('');
+        try {
+            if (typeof body === 'object') {
+                lines.push(JSON.stringify(body, null, 2));
+            } else {
+                lines.push(String(body));
+            }
+        } catch {
+            lines.push(String(body));
+        }
+    }
+    return lines.join('\n');
+});
+
+
+function copyRequestText() {
+    const text = formattedRequest.value;
+    if (!text) return;
+    navigator.clipboard.writeText(text).then(() => {
+        antMessage.success('已复制请求原文');
+    }).catch(() => {
+        antMessage.error('复制失败');
+    });
+}
 
 function open(vendor: Vendor, defaultModel?: string, info?: ModelInfo) {
     currentVendor.value = vendor;
@@ -489,5 +546,24 @@ defineExpose({ open });
     overflow: auto;
     white-space: pre-wrap;
     word-break: break-all;
+}
+
+.request-body {
+    background: #1e222a;
+    color: #abb2bf;
+    padding: 12px;
+    border-radius: 4px;
+    font-size: 12px;
+    max-height: 300px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
+}
+
+.copy-btn {
+    float: right;
+    padding: 0;
+    height: auto;
+    font-size: 12px;
 }
 </style>

--- a/src/controller/vendorController.ts
+++ b/src/controller/vendorController.ts
@@ -246,6 +246,19 @@ async function testVendor(c: Context) {
             responseData = responseText;
         }
 
+        const headerEntries = Array.from(headers.entries()).map(([key, value]) => {
+            if (key.toLowerCase() === 'authorization' || key.toLowerCase() === 'x-api-key') {
+                const visible = value.length > 12 ? value.slice(0, 8) + '****' + value.slice(-4) : '****';
+                return [key, visible];
+            }
+            return [key, value];
+        });
+
+        let requestBodyDisplay: unknown = upstreamBody;
+        try {
+            requestBodyDisplay = JSON.parse(upstreamBody);
+        } catch {}
+
         return c.json({
             success: response.ok,
             status: response.status,
@@ -253,12 +266,32 @@ async function testVendor(c: Context) {
             url,
             converted_from: convertedFrom,
             converted_to: convertedTo,
+            request_method: "POST",
+            request_headers: Object.fromEntries(headerEntries),
+            request_body: requestBodyDisplay,
             response: responseData,
         });
     } catch (error: any) {
+        let requestBodyDisplay: unknown = upstreamBody;
+        try {
+            requestBodyDisplay = JSON.parse(upstreamBody);
+        } catch {}
+
+        const headerEntries = Array.from(headers.entries()).map(([key, value]) => {
+            if (key.toLowerCase() === 'authorization' || key.toLowerCase() === 'x-api-key') {
+                const visible = value.length > 12 ? value.slice(0, 8) + '****' + value.slice(-4) : '****';
+                return [key, visible];
+            }
+            return [key, value];
+        });
+
         return c.json({
             success: false,
             error: error.message || String(error),
+            url,
+            request_method: "POST",
+            request_headers: Object.fromEntries(headerEntries),
+            request_body: requestBodyDisplay,
         }, 500);
     }
 }


### PR DESCRIPTION
Add request_headers and request_body to the vendor test API response, and display them in the test dialog UI between the URL and response sections. Sensitive headers (Authorization, x-api-key) are masked. A copy button is provided for convenience.