### PR TITLE
feat: add vendor auth_mode config for API Key and Bearer Token

### DIFF
--- a/frontend/src/types/vendor.ts
+++ b/frontend/src/types/vendor.ts
@@ -2,6 +2,8 @@ import type { BaseEntity, TableQuery } from './index';
 
 export type VendorType = 'openai' | 'anthropic' | 'google' | 'aliyun' | 'aliyun_coding' | 'volcengine_coding' | 'deepseek' | 'mimo' | 'mimo_token_plan' | 'opencode_go' | 'other';
 
+export type VendorAuthMode = 'api_key' | 'bearer_token';
+
 export interface VendorUrls {
     [key: string]: string;
 }
@@ -11,6 +13,7 @@ export interface Vendor extends BaseEntity {
     name: string;
     token: string;
     urls: VendorUrls;
+    auth_mode: VendorAuthMode;
     model_count: number;
 }
 
@@ -19,6 +22,7 @@ export interface CreateVendorRequest {
     name: string;
     token: string;
     urls?: VendorUrls;
+    auth_mode?: VendorAuthMode;
 }
 
 export interface UpdateVendorRequest {
@@ -26,6 +30,7 @@ export interface UpdateVendorRequest {
     name?: string;
     token?: string;
     urls?: VendorUrls;
+    auth_mode?: VendorAuthMode;
 }
 
 export interface VendorQuery extends TableQuery {

--- a/frontend/src/types/vendor.ts
+++ b/frontend/src/types/vendor.ts
@@ -8,12 +8,17 @@ export interface VendorUrls {
     [key: string]: string;
 }
 
+export interface VendorConfig {
+    auth_mode?: VendorAuthMode;
+    [key: string]: any;
+}
+
 export interface Vendor extends BaseEntity {
     type: VendorType;
     name: string;
     token: string;
     urls: VendorUrls;
-    auth_mode: VendorAuthMode;
+    config: VendorConfig;
     model_count: number;
 }
 
@@ -22,7 +27,7 @@ export interface CreateVendorRequest {
     name: string;
     token: string;
     urls?: VendorUrls;
-    auth_mode?: VendorAuthMode;
+    config?: VendorConfig;
 }
 
 export interface UpdateVendorRequest {
@@ -30,7 +35,7 @@ export interface UpdateVendorRequest {
     name?: string;
     token?: string;
     urls?: VendorUrls;
-    auth_mode?: VendorAuthMode;
+    config?: VendorConfig;
 }
 
 export interface VendorQuery extends TableQuery {

--- a/frontend/src/views/Vendor/Detail.vue
+++ b/frontend/src/views/Vendor/Detail.vue
@@ -16,6 +16,11 @@
                 <a-descriptions-item label="Token">
                     <TokenDisplay :token="vendor.token" />
                 </a-descriptions-item>
+                <a-descriptions-item v-if="vendor.type === 'anthropic'" label="认证方式">
+                    <a-tag :color="vendor.auth_mode === 'bearer_token' ? 'blue' : 'green'">
+                        {{ vendor.auth_mode === 'bearer_token' ? 'Bearer Token (Authorization)' : 'API Key (x-api-key)' }}
+                    </a-tag>
+                </a-descriptions-item>
                 <a-descriptions-item label="URLs">
                     <div v-for="item in getMergedUrls(vendor)" :key="item.key" class="url-item">
                         <strong>{{ item.key }}:</strong> {{ item.url }}

--- a/frontend/src/views/Vendor/Detail.vue
+++ b/frontend/src/views/Vendor/Detail.vue
@@ -16,9 +16,9 @@
                 <a-descriptions-item label="Token">
                     <TokenDisplay :token="vendor.token" />
                 </a-descriptions-item>
-                <a-descriptions-item v-if="vendor.type === 'anthropic'" label="认证方式">
-                    <a-tag :color="vendor.auth_mode === 'bearer_token' ? 'blue' : 'green'">
-                        {{ vendor.auth_mode === 'bearer_token' ? 'Bearer Token (Authorization)' : 'API Key (x-api-key)' }}
+                <a-descriptions-item v-if="vendor.config?.auth_mode" label="认证方式">
+                    <a-tag :color="vendor.config?.auth_mode === 'bearer_token' ? 'blue' : 'green'">
+                        {{ vendor.config?.auth_mode === 'bearer_token' ? 'Bearer Token (Authorization)' : 'API Key (x-api-key)' }}
                     </a-tag>
                 </a-descriptions-item>
                 <a-descriptions-item label="URLs">

--- a/frontend/src/views/Vendor/DialogCreate.vue
+++ b/frontend/src/views/Vendor/DialogCreate.vue
@@ -91,10 +91,10 @@
             <a-collapse v-model:activeKey="advancedActiveKey" :bordered="false" class="advanced-collapse">
                 <a-collapse-panel key="advanced" header="高级设置">
                     <a-form-item label="认证方式" name="auth_mode">
-                        <a-radio-group v-model:value="formState.auth_mode">
-                            <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
-                            <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
-                        </a-radio-group>
+                        <a-select v-model:value="formState.auth_mode" style="width: 100%">
+                            <a-select-option value="api_key">API Key (x-api-key)</a-select-option>
+                            <a-select-option value="bearer_token">Bearer Token (Authorization)</a-select-option>
+                        </a-select>
                     </a-form-item>
                 </a-collapse-panel>
             </a-collapse>

--- a/frontend/src/views/Vendor/DialogCreate.vue
+++ b/frontend/src/views/Vendor/DialogCreate.vue
@@ -31,6 +31,12 @@
                     placeholder="请输入 API Token"
                 />
             </a-form-item>
+            <a-form-item v-if="isAnthropicType" label="认证方式" name="auth_mode">
+                <a-radio-group v-model:value="formState.auth_mode">
+                    <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
+                    <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
+                </a-radio-group>
+            </a-form-item>
             <a-form-item label="URLs 配置（可选）">
                 <!-- 查看模式：合并展示 preset + 用户自定义 -->
                 <template v-if="urlsMode === 'view'">
@@ -93,7 +99,7 @@ import { ref, reactive, computed, watch } from 'vue';
 import type { FormInstance } from 'ant-design-vue/es';
 import { PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons-vue';
 import { createVendor } from '@/api/vendor';
-import type { CreateVendorRequest, Vendor, VendorType, VendorUrls } from '@/types/vendor';
+import type { CreateVendorRequest, Vendor, VendorType, VendorUrls, VendorAuthMode } from '@/types/vendor';
 import { notifyRequestError, notifySuccess } from '@/utils/requestFeedback';
 import { useVendorPresets } from '@/composables/useVendorPresets';
 
@@ -117,6 +123,7 @@ const formState = reactive({
     type: 'openai' as VendorType,
     name: '',
     token: '',
+    auth_mode: 'api_key' as VendorAuthMode,
 });
 
 const urlsMode = ref<'view' | 'edit'>('view');
@@ -143,9 +150,15 @@ const mergedUrls = computed(() => {
         }));
 });
 
+const isAnthropicType = computed(() => formState.type === 'anthropic');
+
 watch(() => formState.type, (newType) => {
     urlsForm.splice(0, urlsForm.length);
     urlsMode.value = PRESET_URLS.value[newType] ? 'view' : 'edit';
+    // 非 anthropic 类型重置为默认 api_key
+    if (newType !== 'anthropic') {
+        formState.auth_mode = 'api_key';
+    }
 });
 
 const rules = {
@@ -159,6 +172,7 @@ function open() {
     formState.type = 'openai';
     formState.name = '';
     formState.token = '';
+    formState.auth_mode = 'api_key';
     urlsForm.splice(0, urlsForm.length);
     urlsMode.value = 'view';
     visible.value = true;
@@ -189,6 +203,10 @@ async function handleOk() {
             name: formState.name,
             token: formState.token,
         };
+
+        if (isAnthropicType.value) {
+            createData.auth_mode = formState.auth_mode;
+        }
 
         // 只提交用户自定义的 URLs，后端对未定义的 key 回退到 preset
         const customUrls = urlsForm.filter(item => item.url);
@@ -259,5 +277,10 @@ defineExpose({ open });
     padding: 0;
     margin-top: 6px;
     height: auto;
+}
+
+.auth-hint {
+    color: #8c8c8c;
+    font-size: 12px;
 }
 </style>

--- a/frontend/src/views/Vendor/DialogCreate.vue
+++ b/frontend/src/views/Vendor/DialogCreate.vue
@@ -90,12 +90,13 @@
             <!-- 高级设置 -->
             <a-collapse v-model:activeKey="advancedActiveKey" :bordered="false" class="advanced-collapse">
                 <a-collapse-panel key="advanced" header="高级设置">
-                    <a-form-item label="认证方式" name="auth_mode">
-                        <a-select v-model:value="formState.auth_mode" style="width: 100%">
+                    <div class="advanced-row">
+                        <label class="advanced-label">认证方式</label>
+                        <a-select v-model:value="formState.auth_mode" style="flex: 1">
                             <a-select-option value="api_key">API Key (x-api-key)</a-select-option>
                             <a-select-option value="bearer_token">Bearer Token (Authorization)</a-select-option>
                         </a-select>
-                    </a-form-item>
+                    </div>
                 </a-collapse-panel>
             </a-collapse>
         </a-form>
@@ -318,5 +319,17 @@ defineExpose({ open });
 
 :deep(.advanced-collapse .ant-collapse-content-box) {
     padding: 0 16px 12px;
+}
+
+.advanced-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.advanced-label {
+    flex-shrink: 0;
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.88);
 }
 </style>

--- a/frontend/src/views/Vendor/DialogCreate.vue
+++ b/frontend/src/views/Vendor/DialogCreate.vue
@@ -207,7 +207,7 @@ async function handleOk() {
             type: formState.type,
             name: formState.name,
             token: formState.token,
-            auth_mode: formState.auth_mode,
+            config: { auth_mode: formState.auth_mode },
         };
 
         // 只提交用户自定义的 URLs，后端对未定义的 key 回退到 preset

--- a/frontend/src/views/Vendor/DialogCreate.vue
+++ b/frontend/src/views/Vendor/DialogCreate.vue
@@ -31,13 +31,13 @@
                     placeholder="请输入 API Token"
                 />
             </a-form-item>
-            <a-form-item v-if="isAnthropicType" label="认证方式" name="auth_mode">
-                <a-radio-group v-model:value="formState.auth_mode">
-                    <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
-                    <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
-                </a-radio-group>
-            </a-form-item>
-            <a-form-item label="URLs 配置（可选）">
+            <div class="urls-header">
+                <label class="ant-form-item-label">URLs 配置（可选）</label>
+                <a-button v-if="urlsMode === 'view'" type="link" size="small" class="toggle-btn" @click="switchToEditMode">
+                    <EditOutlined /> 编辑
+                </a-button>
+            </div>
+            <a-form-item>
                 <!-- 查看模式：合并展示 preset + 用户自定义 -->
                 <template v-if="urlsMode === 'view'">
                     <div class="urls-view">
@@ -47,9 +47,6 @@
                             <a-tag v-if="item.isCustom" color="blue" class="custom-tag">自定义</a-tag>
                         </div>
                     </div>
-                    <a-button type="link" size="small" class="toggle-btn" @click="switchToEditMode">
-                        <EditOutlined /> 编辑
-                    </a-button>
                 </template>
                 <!-- 编辑模式：仅用户自定义条目，初始为空 -->
                 <template v-else>
@@ -90,6 +87,17 @@
                     </a-button>
                 </template>
             </a-form-item>
+            <!-- 高级设置 -->
+            <a-collapse v-model:activeKey="advancedActiveKey" :bordered="false" class="advanced-collapse">
+                <a-collapse-panel key="advanced" header="高级设置">
+                    <a-form-item label="认证方式" name="auth_mode">
+                        <a-radio-group v-model:value="formState.auth_mode">
+                            <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
+                            <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
+                        </a-radio-group>
+                    </a-form-item>
+                </a-collapse-panel>
+            </a-collapse>
         </a-form>
     </a-modal>
 </template>
@@ -110,6 +118,7 @@ const emit = defineEmits<{
 const visible = ref(false);
 const loading = ref(false);
 const formRef = ref<FormInstance>();
+const advancedActiveKey = ref<string[]>([]);
 
 const URL_TYPES = [
     { label: 'OpenAI', value: 'openai' },
@@ -150,15 +159,9 @@ const mergedUrls = computed(() => {
         }));
 });
 
-const isAnthropicType = computed(() => formState.type === 'anthropic');
-
 watch(() => formState.type, (newType) => {
     urlsForm.splice(0, urlsForm.length);
     urlsMode.value = PRESET_URLS.value[newType] ? 'view' : 'edit';
-    // 非 anthropic 类型重置为默认 api_key
-    if (newType !== 'anthropic') {
-        formState.auth_mode = 'api_key';
-    }
 });
 
 const rules = {
@@ -173,6 +176,7 @@ function open() {
     formState.name = '';
     formState.token = '';
     formState.auth_mode = 'api_key';
+    advancedActiveKey.value = [];
     urlsForm.splice(0, urlsForm.length);
     urlsMode.value = 'view';
     visible.value = true;
@@ -202,11 +206,8 @@ async function handleOk() {
             type: formState.type,
             name: formState.name,
             token: formState.token,
+            auth_mode: formState.auth_mode,
         };
-
-        if (isAnthropicType.value) {
-            createData.auth_mode = formState.auth_mode;
-        }
 
         // 只提交用户自定义的 URLs，后端对未定义的 key 回退到 preset
         const customUrls = urlsForm.filter(item => item.url);
@@ -279,8 +280,43 @@ defineExpose({ open });
     height: auto;
 }
 
+.urls-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.urls-header .ant-form-item-label {
+    margin-bottom: 0;
+}
+
+.urls-header .toggle-btn {
+    margin-top: 0;
+}
+
 .auth-hint {
     color: #8c8c8c;
     font-size: 12px;
+}
+
+.advanced-collapse {
+    background: transparent;
+    border: none;
+    margin-top: 8px;
+}
+
+:deep(.advanced-collapse .ant-collapse-item) {
+    border: 1px solid var(--border-color, #d9d9d9);
+    border-radius: 6px;
+}
+
+:deep(.advanced-collapse .ant-collapse-header) {
+    padding: 8px 16px;
+    font-size: 13px;
+}
+
+:deep(.advanced-collapse .ant-collapse-content-box) {
+    padding: 0 16px 12px;
 }
 </style>

--- a/frontend/src/views/Vendor/DialogCreate.vue
+++ b/frontend/src/views/Vendor/DialogCreate.vue
@@ -176,7 +176,7 @@ function open() {
     formState.type = 'openai';
     formState.name = '';
     formState.token = '';
-    formState.auth_mode = 'api_key';
+    formState.auth_mode = 'bearer_token';
     advancedActiveKey.value = [];
     urlsForm.splice(0, urlsForm.length);
     urlsMode.value = 'view';

--- a/frontend/src/views/Vendor/DialogEdit.vue
+++ b/frontend/src/views/Vendor/DialogEdit.vue
@@ -31,6 +31,12 @@
                     placeholder="请输入 API Token"
                 />
             </a-form-item>
+            <a-form-item v-if="isAnthropicType" label="认证方式" name="auth_mode">
+                <a-radio-group v-model:value="formState.auth_mode">
+                    <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
+                    <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
+                </a-radio-group>
+            </a-form-item>
             <a-form-item label="URLs 配置">
                 <!-- 查看模式：合并展示 preset + 用户自定义 -->
                 <template v-if="urlsMode === 'view'">
@@ -93,7 +99,7 @@ import { ref, reactive, computed, watch } from 'vue';
 import type { FormInstance } from 'ant-design-vue/es';
 import { PlusOutlined, DeleteOutlined, EditOutlined } from '@ant-design/icons-vue';
 import { updateVendor } from '@/api/vendor';
-import type { UpdateVendorRequest, Vendor, VendorType, VendorUrls } from '@/types/vendor';
+import type { UpdateVendorRequest, Vendor, VendorType, VendorUrls, VendorAuthMode } from '@/types/vendor';
 import { notifyRequestError, notifySuccess } from '@/utils/requestFeedback';
 import { useVendorPresets } from '@/composables/useVendorPresets';
 
@@ -119,6 +125,7 @@ const formState = reactive({
     type: 'openai' as VendorType,
     name: '',
     token: '',
+    auth_mode: 'api_key' as VendorAuthMode,
 });
 
 const urlsMode = ref<'view' | 'edit'>('view');
@@ -145,9 +152,15 @@ const mergedUrls = computed(() => {
         }));
 });
 
+const isAnthropicType = computed(() => formState.type === 'anthropic');
+
 // 切换类型时只更新模式，保留用户已填写的自定义 URLs
 watch(() => formState.type, (newType) => {
     urlsMode.value = PRESET_URLS.value[newType] ? 'view' : 'edit';
+    // 非 anthropic 类型重置为默认 api_key
+    if (newType !== 'anthropic') {
+        formState.auth_mode = 'api_key';
+    }
 });
 
 const rules = {
@@ -161,6 +174,7 @@ function open(vendor: Vendor) {
     formState.type = vendor.type;
     formState.name = vendor.name;
     formState.token = vendor.token;
+    formState.auth_mode = vendor.auth_mode || 'api_key';
 
     // 加载已保存的自定义 URLs
     urlsForm.splice(0, urlsForm.length);
@@ -200,6 +214,10 @@ async function handleOk() {
             token: formState.token,
             urls,
         };
+
+        if (isAnthropicType.value) {
+            updateData.auth_mode = formState.auth_mode;
+        }
 
         loading.value = true;
         const vendor = await updateVendor(currentId.value, updateData);
@@ -262,5 +280,10 @@ defineExpose({ open });
     padding: 0;
     margin-top: 6px;
     height: auto;
+}
+
+.auth-hint {
+    color: #8c8c8c;
+    font-size: 12px;
 }
 </style>

--- a/frontend/src/views/Vendor/DialogEdit.vue
+++ b/frontend/src/views/Vendor/DialogEdit.vue
@@ -91,10 +91,10 @@
             <a-collapse v-model:activeKey="advancedActiveKey" :bordered="false" class="advanced-collapse">
                 <a-collapse-panel key="advanced" header="高级设置">
                     <a-form-item label="认证方式" name="auth_mode">
-                        <a-radio-group v-model:value="formState.auth_mode">
-                            <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
-                            <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
-                        </a-radio-group>
+                        <a-select v-model:value="formState.auth_mode" style="width: 100%">
+                            <a-select-option value="api_key">API Key (x-api-key)</a-select-option>
+                            <a-select-option value="bearer_token">Bearer Token (Authorization)</a-select-option>
+                        </a-select>
                     </a-form-item>
                 </a-collapse-panel>
             </a-collapse>

--- a/frontend/src/views/Vendor/DialogEdit.vue
+++ b/frontend/src/views/Vendor/DialogEdit.vue
@@ -90,12 +90,13 @@
             <!-- 高级设置 -->
             <a-collapse v-model:activeKey="advancedActiveKey" :bordered="false" class="advanced-collapse">
                 <a-collapse-panel key="advanced" header="高级设置">
-                    <a-form-item label="认证方式" name="auth_mode">
-                        <a-select v-model:value="formState.auth_mode" style="width: 100%">
+                    <div class="advanced-row">
+                        <label class="advanced-label">认证方式</label>
+                        <a-select v-model:value="formState.auth_mode" style="flex: 1">
                             <a-select-option value="api_key">API Key (x-api-key)</a-select-option>
                             <a-select-option value="bearer_token">Bearer Token (Authorization)</a-select-option>
                         </a-select>
-                    </a-form-item>
+                    </div>
                 </a-collapse-panel>
             </a-collapse>
         </a-form>
@@ -321,5 +322,17 @@ defineExpose({ open });
 
 :deep(.advanced-collapse .ant-collapse-content-box) {
     padding: 0 16px 12px;
+}
+
+.advanced-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.advanced-label {
+    flex-shrink: 0;
+    font-size: 14px;
+    color: rgba(0, 0, 0, 0.88);
 }
 </style>

--- a/frontend/src/views/Vendor/DialogEdit.vue
+++ b/frontend/src/views/Vendor/DialogEdit.vue
@@ -31,13 +31,13 @@
                     placeholder="请输入 API Token"
                 />
             </a-form-item>
-            <a-form-item v-if="isAnthropicType" label="认证方式" name="auth_mode">
-                <a-radio-group v-model:value="formState.auth_mode">
-                    <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
-                    <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
-                </a-radio-group>
-            </a-form-item>
-            <a-form-item label="URLs 配置">
+            <div class="urls-header">
+                <label class="ant-form-item-label">URLs 配置</label>
+                <a-button v-if="urlsMode === 'view'" type="link" size="small" class="toggle-btn" @click="urlsMode = 'edit'">
+                    <EditOutlined /> 编辑
+                </a-button>
+            </div>
+            <a-form-item>
                 <!-- 查看模式：合并展示 preset + 用户自定义 -->
                 <template v-if="urlsMode === 'view'">
                     <div class="urls-view">
@@ -47,9 +47,6 @@
                             <a-tag v-if="item.isCustom" color="blue" class="custom-tag">自定义</a-tag>
                         </div>
                     </div>
-                    <a-button type="link" size="small" class="toggle-btn" @click="urlsMode = 'edit'">
-                        <EditOutlined /> 编辑
-                    </a-button>
                 </template>
                 <!-- 编辑模式：仅用户自定义条目 -->
                 <template v-else>
@@ -90,6 +87,17 @@
                     </a-button>
                 </template>
             </a-form-item>
+            <!-- 高级设置 -->
+            <a-collapse v-model:activeKey="advancedActiveKey" :bordered="false" class="advanced-collapse">
+                <a-collapse-panel key="advanced" header="高级设置">
+                    <a-form-item label="认证方式" name="auth_mode">
+                        <a-radio-group v-model:value="formState.auth_mode">
+                            <a-radio value="api_key">API Key <span class="auth-hint">(x-api-key)</span></a-radio>
+                            <a-radio value="bearer_token">Bearer Token <span class="auth-hint">(Authorization)</span></a-radio>
+                        </a-radio-group>
+                    </a-form-item>
+                </a-collapse-panel>
+            </a-collapse>
         </a-form>
     </a-modal>
 </template>
@@ -110,6 +118,7 @@ const emit = defineEmits<{
 const visible = ref(false);
 const loading = ref(false);
 const formRef = ref<FormInstance>();
+const advancedActiveKey = ref<string[]>([]);
 
 const URL_TYPES = [
     { label: 'OpenAI', value: 'openai' },
@@ -152,15 +161,9 @@ const mergedUrls = computed(() => {
         }));
 });
 
-const isAnthropicType = computed(() => formState.type === 'anthropic');
-
 // 切换类型时只更新模式，保留用户已填写的自定义 URLs
 watch(() => formState.type, (newType) => {
     urlsMode.value = PRESET_URLS.value[newType] ? 'view' : 'edit';
-    // 非 anthropic 类型重置为默认 api_key
-    if (newType !== 'anthropic') {
-        formState.auth_mode = 'api_key';
-    }
 });
 
 const rules = {
@@ -184,6 +187,7 @@ function open(vendor: Vendor) {
 
     void loadPresets();
     urlsMode.value = PRESET_URLS.value[vendor.type] ? 'view' : 'edit';
+    advancedActiveKey.value = [];
     visible.value = true;
 }
 
@@ -213,11 +217,8 @@ async function handleOk() {
             name: formState.name,
             token: formState.token,
             urls,
+            auth_mode: formState.auth_mode,
         };
-
-        if (isAnthropicType.value) {
-            updateData.auth_mode = formState.auth_mode;
-        }
 
         loading.value = true;
         const vendor = await updateVendor(currentId.value, updateData);
@@ -282,8 +283,43 @@ defineExpose({ open });
     height: auto;
 }
 
+.urls-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+
+.urls-header .ant-form-item-label {
+    margin-bottom: 0;
+}
+
+.urls-header .toggle-btn {
+    margin-top: 0;
+}
+
 .auth-hint {
     color: #8c8c8c;
     font-size: 12px;
+}
+
+.advanced-collapse {
+    background: transparent;
+    border: none;
+    margin-top: 8px;
+}
+
+:deep(.advanced-collapse .ant-collapse-item) {
+    border: 1px solid var(--border-color, #d9d9d9);
+    border-radius: 6px;
+}
+
+:deep(.advanced-collapse .ant-collapse-header) {
+    padding: 8px 16px;
+    font-size: 13px;
+}
+
+:deep(.advanced-collapse .ant-collapse-content-box) {
+    padding: 0 16px 12px;
 }
 </style>

--- a/frontend/src/views/Vendor/DialogEdit.vue
+++ b/frontend/src/views/Vendor/DialogEdit.vue
@@ -178,7 +178,7 @@ function open(vendor: Vendor) {
     formState.type = vendor.type;
     formState.name = vendor.name;
     formState.token = vendor.token;
-    formState.auth_mode = vendor.auth_mode || 'bearer_token';
+    formState.auth_mode = vendor.config?.auth_mode || 'bearer_token';
 
     // 加载已保存的自定义 URLs
     urlsForm.splice(0, urlsForm.length);
@@ -218,7 +218,7 @@ async function handleOk() {
             name: formState.name,
             token: formState.token,
             urls,
-            auth_mode: formState.auth_mode,
+            config: { auth_mode: formState.auth_mode },
         };
 
         loading.value = true;

--- a/frontend/src/views/Vendor/DialogEdit.vue
+++ b/frontend/src/views/Vendor/DialogEdit.vue
@@ -135,7 +135,7 @@ const formState = reactive({
     type: 'openai' as VendorType,
     name: '',
     token: '',
-    auth_mode: 'api_key' as VendorAuthMode,
+    auth_mode: 'bearer_token' as VendorAuthMode,
 });
 
 const urlsMode = ref<'view' | 'edit'>('view');
@@ -178,7 +178,7 @@ function open(vendor: Vendor) {
     formState.type = vendor.type;
     formState.name = vendor.name;
     formState.token = vendor.token;
-    formState.auth_mode = vendor.auth_mode || 'api_key';
+    formState.auth_mode = vendor.auth_mode || 'bearer_token';
 
     // 加载已保存的自定义 URLs
     urlsForm.splice(0, urlsForm.length);

--- a/resource/migrate/migrate_0021.sql
+++ b/resource/migrate/migrate_0021.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vendor ADD COLUMN auth_mode TEXT DEFAULT 'api_key' NOT NULL;

--- a/resource/migrate/migrate_0021.sql
+++ b/resource/migrate/migrate_0021.sql
@@ -1,1 +1,1 @@
-ALTER TABLE vendor ADD COLUMN auth_mode TEXT DEFAULT 'bearer_token' NOT NULL;
+ALTER TABLE vendor ADD COLUMN config TEXT DEFAULT '{}' NOT NULL;

--- a/resource/migrate/migrate_0021.sql
+++ b/resource/migrate/migrate_0021.sql
@@ -1,1 +1,1 @@
-ALTER TABLE vendor ADD COLUMN auth_mode TEXT DEFAULT 'api_key' NOT NULL;
+ALTER TABLE vendor ADD COLUMN auth_mode TEXT DEFAULT 'bearer_token' NOT NULL;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,12 @@ export enum VendorType {
     OTHER = "other",
 }
 
+
+export enum VendorAuthMode {
+    API_KEY = "api_key",
+    BEARER_TOKEN = "bearer_token",
+}
+
 export enum ApiFormat {
     OPENAI = "openai",
     ANTHROPIC = "anthropic",

--- a/src/controller/vendorController.ts
+++ b/src/controller/vendorController.ts
@@ -6,7 +6,7 @@ import vendorDefaultUrls from "../service/vendorDefaultUrls";
 import ormService from "../service/ormService";
 import senderService from "../service/senderService";
 import customError from "../util/customError";
-import { ApiFormat } from "../constants";
+import { ApiFormat, VendorAuthMode } from "../constants";
 import { createListResponse, parsePaginationQuery } from "../util/pagination";
 
 
@@ -20,6 +20,7 @@ function formatVendor(vendor: SgVendor, modelCount = 0) {
         name: vendor.name,
         token: vendor.token,
         urls: vendor.getUrls(),
+        auth_mode: vendor.getAuthMode(),
         model_count: modelCount,
         created_at: vendor.created_at,
         updated_at: vendor.updated_at,
@@ -100,18 +101,23 @@ async function getVendorsByIds(c: Context) {
 
 async function createVendor(c: Context) {
     const body = await c.req.json();
-    const { type, name, token, urls } = body;
+    const { type, name, token, urls, auth_mode } = body;
 
     // Validation - 不验证 urls，允许为空
     if (!type || !name || !token) {
         throw new customError.AppError("Missing required fields");
     }
 
+    const finalAuthMode = auth_mode === VendorAuthMode.BEARER_TOKEN
+        ? VendorAuthMode.BEARER_TOKEN
+        : VendorAuthMode.API_KEY;
+
     const instance = await SgVendor.query().create({
         type,
         name,
         token,
         urls: urls ? JSON.stringify(urls) : "{}",
+        auth_mode: finalAuthMode,
     });
 
     return c.json(formatVendor(instance));
@@ -127,13 +133,14 @@ async function updateVendor(c: Context) {
     }
 
     const body = await c.req.json();
-    const { type, name, token, urls } = body;
+    const { type, name, token, urls, auth_mode } = body;
 
     const updatedVendor = await vendorService.updateVendor(vendorId, {
         type,
         name,
         token,
         urls,
+        auth_mode,
     });
 
     if (!updatedVendor) {
@@ -203,8 +210,12 @@ async function testVendor(c: Context) {
     let upstreamBody = "";
 
     if (requestFormat === ApiFormat.ANTHROPIC) {
-        headers.set("x-api-key", vendor.token);
-        headers.set("anthropic-version", "2023-06-01");
+        if (vendor.isBearerTokenAuth()) {
+            headers.set("Authorization", vendor.token.startsWith("Bearer ") ? vendor.token : `Bearer ${vendor.token}`);
+        } else {
+            headers.set("x-api-key", vendor.token);
+            headers.set("anthropic-version", "2023-06-01");
+        }
         headers.set("Content-Type", "application/json");
         upstreamBody = JSON.stringify({
             model: model,

--- a/src/controller/vendorController.ts
+++ b/src/controller/vendorController.ts
@@ -20,7 +20,7 @@ function formatVendor(vendor: SgVendor, modelCount = 0) {
         name: vendor.name,
         token: vendor.token,
         urls: vendor.getUrls(),
-        auth_mode: vendor.getAuthMode(),
+        config: vendor.getConfig(),
         model_count: modelCount,
         created_at: vendor.created_at,
         updated_at: vendor.updated_at,
@@ -101,23 +101,21 @@ async function getVendorsByIds(c: Context) {
 
 async function createVendor(c: Context) {
     const body = await c.req.json();
-    const { type, name, token, urls, auth_mode } = body;
+    const { type, name, token, urls, config } = body;
 
     // Validation - 不验证 urls，允许为空
     if (!type || !name || !token) {
         throw new customError.AppError("Missing required fields");
     }
 
-    const finalAuthMode = auth_mode === VendorAuthMode.BEARER_TOKEN
-        ? VendorAuthMode.BEARER_TOKEN
-        : VendorAuthMode.API_KEY;
+    const finalConfig = config || {};
 
     const instance = await SgVendor.query().create({
         type,
         name,
         token,
         urls: urls ? JSON.stringify(urls) : "{}",
-        auth_mode: finalAuthMode,
+        config: JSON.stringify(finalConfig),
     });
 
     return c.json(formatVendor(instance));
@@ -133,14 +131,14 @@ async function updateVendor(c: Context) {
     }
 
     const body = await c.req.json();
-    const { type, name, token, urls, auth_mode } = body;
+    const { type, name, token, urls, config } = body;
 
     const updatedVendor = await vendorService.updateVendor(vendorId, {
         type,
         name,
         token,
         urls,
-        auth_mode,
+        config,
     });
 
     if (!updatedVendor) {

--- a/src/model/sgVendor.ts
+++ b/src/model/sgVendor.ts
@@ -1,6 +1,6 @@
 import { Model } from "sutando";
 import { inspect, InspectOptions } from "util";
-import { VendorType, ApiFormat } from "../constants";
+import { VendorType, ApiFormat, VendorAuthMode } from "../constants";
 import vendorDefaultUrls from "../service/vendorDefaultUrls";
 import customError from "../util/customError";
 import urlUtil from "../util/urlUtil";
@@ -13,6 +13,7 @@ class SgVendor extends Model {
     name!: string;
     token!: string;
     urls!: string;  // JSON string
+    auth_mode!: VendorAuthMode;
 
     created_at!: Date;
     updated_at!: Date;
@@ -98,6 +99,24 @@ class SgVendor extends Model {
 
         return formats;
     }
+
+    /**
+     * 获取当前 vendor 的认证模式，默认为 api_key
+     */
+    getAuthMode(): VendorAuthMode {
+        return this.auth_mode === VendorAuthMode.BEARER_TOKEN
+            ? VendorAuthMode.BEARER_TOKEN
+            : VendorAuthMode.API_KEY;
+    }
+
+
+    /**
+     * 判断是否使用 Bearer Token 认证方式
+     */
+    isBearerTokenAuth(): boolean {
+        return this.getAuthMode() === VendorAuthMode.BEARER_TOKEN;
+    }
+
 
     [inspect.custom](depth: number, options: InspectOptions) {
         return JSON.stringify(this.toData(), null, 2);

--- a/src/model/sgVendor.ts
+++ b/src/model/sgVendor.ts
@@ -13,7 +13,7 @@ class SgVendor extends Model {
     name!: string;
     token!: string;
     urls!: string;  // JSON string
-    auth_mode!: VendorAuthMode;
+    config!: string;  // JSON string
 
     created_at!: Date;
     updated_at!: Date;
@@ -24,6 +24,17 @@ class SgVendor extends Model {
     getUrls(): Record<string, string> {
         try {
             return this.urls ? JSON.parse(this.urls) : {};
+        } catch {
+            return {};
+        }
+    }
+
+    /**
+     * Parse config JSON string to object
+     */
+    getConfig(): Record<string, any> {
+        try {
+            return this.config ? JSON.parse(this.config) : {};
         } catch {
             return {};
         }
@@ -104,7 +115,8 @@ class SgVendor extends Model {
      * 获取当前 vendor 的认证模式，默认为 bearer_token
      */
     getAuthMode(): VendorAuthMode {
-        return this.auth_mode === VendorAuthMode.API_KEY
+        const config = this.getConfig();
+        return config.auth_mode === VendorAuthMode.API_KEY
             ? VendorAuthMode.API_KEY
             : VendorAuthMode.BEARER_TOKEN;
     }

--- a/src/model/sgVendor.ts
+++ b/src/model/sgVendor.ts
@@ -101,12 +101,12 @@ class SgVendor extends Model {
     }
 
     /**
-     * 获取当前 vendor 的认证模式，默认为 api_key
+     * 获取当前 vendor 的认证模式，默认为 bearer_token
      */
     getAuthMode(): VendorAuthMode {
-        return this.auth_mode === VendorAuthMode.BEARER_TOKEN
-            ? VendorAuthMode.BEARER_TOKEN
-            : VendorAuthMode.API_KEY;
+        return this.auth_mode === VendorAuthMode.API_KEY
+            ? VendorAuthMode.API_KEY
+            : VendorAuthMode.BEARER_TOKEN;
     }
 
 

--- a/src/service/senderService.ts
+++ b/src/service/senderService.ts
@@ -836,8 +836,12 @@ async function sendRequest(
     }
 
     if (upstreamFormat === ApiFormat.ANTHROPIC) {
-        finalHeaders.set("x-api-key", vendor.token);
-        finalHeaders.set("anthropic-version", "2023-06-01");
+        if (vendor.isBearerTokenAuth()) {
+            finalHeaders.set("Authorization", vendor.token.startsWith("Bearer ") ? vendor.token : `Bearer ${vendor.token}`);
+        } else {
+            finalHeaders.set("x-api-key", vendor.token);
+            finalHeaders.set("anthropic-version", "2023-06-01");
+        }
     } else {
         finalHeaders.set("Authorization", vendor.token.startsWith("Bearer ") ? vendor.token : `Bearer ${vendor.token}`);
     }

--- a/src/service/vendorService.ts
+++ b/src/service/vendorService.ts
@@ -1,5 +1,5 @@
 import { SgVendor } from "../model/sgVendor";
-import { ApiFormat } from "../constants";
+import { ApiFormat, VendorAuthMode } from "../constants";
 
 
 async function getVendorByName(name: string): Promise<SgVendor | null> {
@@ -13,7 +13,7 @@ async function getVendorByName(name: string): Promise<SgVendor | null> {
 
 async function updateVendor(
     vendorId: number,
-    data: { type?: string; name?: string; token?: string; urls?: Record<string, string> },
+    data: { type?: string; name?: string; token?: string; urls?: Record<string, string>; auth_mode?: string },
 ): Promise<SgVendor | null> {
     const vendor = await SgVendor.query().find(vendorId);
 
@@ -30,6 +30,13 @@ async function updateVendor(
     // Handle urls - if provided, serialize as JSON string
     if (data.urls !== undefined) {
         updateData.urls = JSON.stringify(data.urls);
+    }
+
+    // Handle auth_mode
+    if (data.auth_mode !== undefined) {
+        updateData.auth_mode = data.auth_mode === VendorAuthMode.BEARER_TOKEN
+            ? VendorAuthMode.BEARER_TOKEN
+            : VendorAuthMode.API_KEY;
     }
 
     await SgVendor.query()

--- a/src/service/vendorService.ts
+++ b/src/service/vendorService.ts
@@ -13,7 +13,7 @@ async function getVendorByName(name: string): Promise<SgVendor | null> {
 
 async function updateVendor(
     vendorId: number,
-    data: { type?: string; name?: string; token?: string; urls?: Record<string, string>; auth_mode?: string },
+    data: { type?: string; name?: string; token?: string; urls?: Record<string, string>; config?: Record<string, any> },
 ): Promise<SgVendor | null> {
     const vendor = await SgVendor.query().find(vendorId);
 
@@ -32,11 +32,9 @@ async function updateVendor(
         updateData.urls = JSON.stringify(data.urls);
     }
 
-    // Handle auth_mode
-    if (data.auth_mode !== undefined) {
-        updateData.auth_mode = data.auth_mode === VendorAuthMode.BEARER_TOKEN
-            ? VendorAuthMode.BEARER_TOKEN
-            : VendorAuthMode.API_KEY;
+    // Handle config - if provided, serialize as JSON string
+    if (data.config !== undefined) {
+        updateData.config = JSON.stringify(data.config);
     }
 
     await SgVendor.query()


### PR DESCRIPTION
支持供应商认证方式配置（API Key / Bearer Token），存储在 vendor.config JSON 字段中。