### PR TITLE
feat(api): add LLM models endpoint

### DIFF
--- a/doc/usage/LlmApiUsage.md
+++ b/doc/usage/LlmApiUsage.md
@@ -14,6 +14,13 @@
 Authorization: Bearer YOUR_USER_TOKEN
 ```
 
+模型列表端点同时支持 Bearer Token 和 `x-api-key`：
+
+```http
+GET /llm/v1/models
+Authorization: Bearer YOUR_USER_TOKEN
+```
+
 ### 2. Anthropic 兼容协议 (x-api-key 或 Bearer Token)
 支持两种方式：
 - 使用 `x-api-key` (推荐):

--- a/src/controller/modelController.ts
+++ b/src/controller/modelController.ts
@@ -81,6 +81,15 @@ async function listModels(c: Context) {
 }
 
 
+async function listLlmModels(c: Context) {
+    const models = await modelService.listEnabledModels();
+    return c.json({
+        object: "list",
+        data: models,
+    });
+}
+
+
 async function getModel(c: Context) {
     const id = c.req.param("id");
     const modelId = parseInt(id, 10);
@@ -154,6 +163,7 @@ async function updateModel(c: Context) {
 export default {
     createModel,
     listModels,
+    listLlmModels,
     getModel,
     getModelsByIds,
     updateModel,

--- a/src/middleware/corsMiddleware.ts
+++ b/src/middleware/corsMiddleware.ts
@@ -13,7 +13,7 @@ const allowCors = cors({
         }
         return null;
     },
-    allowHeaders: ["Content-Type", "Authorization"],
+    allowHeaders: ["Content-Type", "Authorization", "x-api-key"],
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     credentials: true,
 });

--- a/src/middleware/llmApiMiddleware.ts
+++ b/src/middleware/llmApiMiddleware.ts
@@ -4,46 +4,52 @@ import userService from "../service/userService";
 import modelService from "../service/modelService";
 import recordService from "../service/recordService";
 import { SgVendor } from "../model/sgVendor";
+import { SgUser } from "../model/sgUser";
 import customError from "../util/customError";
 
-export const requireLlmAuth = (format: ApiFormat): MiddlewareHandler => {
+
+function getLlmToken(c: Context, allowApiKey: boolean): string {
+    if (allowApiKey) {
+        const apiKey = c.req.header("x-api-key");
+        if (apiKey) {
+            return apiKey;
+        }
+    }
+
+    const authHeader = c.req.header("Authorization");
+    if (!authHeader) {
+        const message = allowApiKey
+            ? "x-api-key or Authorization header is missing"
+            : "Authorization header is missing";
+        throw new customError.AppError(message, 401, "authentication_error");
+    }
+    if (!authHeader.startsWith("Bearer ")) {
+        throw new customError.AppError("Invalid token format", 401, "authentication_error");
+    }
+
+    return authHeader.split(" ")[1];
+}
+
+
+async function authenticateLlmUser(c: Context, allowApiKey: boolean): Promise<SgUser> {
+    const token = getLlmToken(c, allowApiKey);
+    const user = await userService.getUserByToken(token, c.env.ROOT_TOKEN);
+
+    if (user == null) {
+        throw new customError.AppError("Invalid token (user not found)", 401, "authentication_error");
+    }
+    if (user.status === UserStatus.DISABLED) {
+        throw new customError.AppError("User disabled", 403, "authentication_error");
+    }
+
+    return user;
+}
+
+
+const requireLlmAuth = (format: ApiFormat): MiddlewareHandler => {
     return async (c: Context, next) => {
         c.set("api_format", format);
-        
-        let token: string | undefined;
-
-        if (format === ApiFormat.ANTHROPIC) {
-            const apiKey = c.req.header("x-api-key");
-            token = apiKey;
-            if (!token) {
-                const authHeader = c.req.header("Authorization");
-                if (authHeader && authHeader.startsWith("Bearer ")) {
-                    token = authHeader.split(" ")[1];
-                }
-            }
-            if (!token) {
-                throw new customError.AppError("x-api-key or Authorization header is missing", 401, "authentication_error");
-            }
-        } else {
-            const authHeader = c.req.header("Authorization");
-            if (!authHeader) {
-                throw new customError.AppError("Authorization header is missing", 401, "authentication_error");
-            }
-            if (!authHeader.startsWith("Bearer ")) {
-                throw new customError.AppError("Invalid token format", 401, "authentication_error");
-            }
-            token = authHeader.split(" ")[1];
-        }
-
-        const user = await userService.getUserByToken(token, c.env.ROOT_TOKEN);
-
-        if (user == null) {
-            throw new customError.AppError("Invalid token (user not found)", 401, "authentication_error");
-        }
-
-        if (user.status === UserStatus.DISABLED) {
-            throw new customError.AppError("User disabled", 403, "authentication_error");
-        }
+        const user = await authenticateLlmUser(c, format === ApiFormat.ANTHROPIC);
 
         const body = await c.req.text();
         c.set("requestBody", body);
@@ -80,29 +86,10 @@ export const requireLlmAuth = (format: ApiFormat): MiddlewareHandler => {
     };
 };
 
-export const requireLlmModelsAuth: MiddlewareHandler = async (c: Context, next) => {
+
+const requireLlmModelsAuth: MiddlewareHandler = async (c: Context, next) => {
     c.set("api_format", ApiFormat.OPENAI);
-
-    let token = c.req.header("x-api-key");
-    if (!token) {
-        const authHeader = c.req.header("Authorization");
-        if (!authHeader) {
-            throw new customError.AppError("x-api-key or Authorization header is missing", 401, "authentication_error");
-        }
-        if (!authHeader.startsWith("Bearer ")) {
-            throw new customError.AppError("Invalid token format", 401, "authentication_error");
-        }
-        token = authHeader.split(" ")[1];
-    }
-
-    const user = await userService.getUserByToken(token, c.env.ROOT_TOKEN);
-    if (user == null) {
-        throw new customError.AppError("Invalid token (user not found)", 401, "authentication_error");
-    }
-    if (user.status === UserStatus.DISABLED) {
-        throw new customError.AppError("User disabled", 403, "authentication_error");
-    }
-
+    const user = await authenticateLlmUser(c, true);
     c.set("user", user);
     await next();
 };

--- a/src/middleware/llmApiMiddleware.ts
+++ b/src/middleware/llmApiMiddleware.ts
@@ -80,4 +80,31 @@ export const requireLlmAuth = (format: ApiFormat): MiddlewareHandler => {
     };
 };
 
-export default { requireLlmAuth };
+export const requireLlmModelsAuth: MiddlewareHandler = async (c: Context, next) => {
+    c.set("api_format", ApiFormat.OPENAI);
+
+    let token = c.req.header("x-api-key");
+    if (!token) {
+        const authHeader = c.req.header("Authorization");
+        if (!authHeader) {
+            throw new customError.AppError("x-api-key or Authorization header is missing", 401, "authentication_error");
+        }
+        if (!authHeader.startsWith("Bearer ")) {
+            throw new customError.AppError("Invalid token format", 401, "authentication_error");
+        }
+        token = authHeader.split(" ")[1];
+    }
+
+    const user = await userService.getUserByToken(token, c.env.ROOT_TOKEN);
+    if (user == null) {
+        throw new customError.AppError("Invalid token (user not found)", 401, "authentication_error");
+    }
+    if (user.status === UserStatus.DISABLED) {
+        throw new customError.AppError("User disabled", 403, "authentication_error");
+    }
+
+    c.set("user", user);
+    await next();
+};
+
+export default { requireLlmAuth, requireLlmModelsAuth };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -167,6 +167,7 @@ app.get("/stats/dashboard.json", authMiddleware.requireAdmin, statsController.da
 app.get("/stats/recent.json", authMiddleware.requireAdmin, statsController.recentRecords);
 
 // AI endpoints (no auth middleware, using custom llmApiAuth)
+app.get("/llm/v1/models", llmApiMiddleware.requireLlmModelsAuth, modelController.listLlmModels);
 app.post("/llm/v1/chat/completions", llmApiMiddleware.requireLlmAuth(ApiFormat.OPENAI), gatewayController.chatCompletions);
 app.post("/llm/v1/messages", llmApiMiddleware.requireLlmAuth(ApiFormat.ANTHROPIC), gatewayController.anthropicMessages);
 app.post("/llm/v1/responses", llmApiMiddleware.requireLlmAuth(ApiFormat.RESPONSES), gatewayController.responsesApi);

--- a/src/service/modelService.ts
+++ b/src/service/modelService.ts
@@ -23,10 +23,10 @@ async function listEnabledModels() {
         .where("enable", 1)
         .orderBy("id", "asc")
         .get();
-    const modelList = models.toArray();
+    const modelList = models.toArray<SgModel>();
     const vendorIds = [...new Set(modelList.map(model => model.vendor_id as number))];
     const vendorList = vendorIds.length > 0
-        ? (await SgVendor.query().whereIn("id", vendorIds).get()).toArray()
+        ? (await SgVendor.query().whereIn("id", vendorIds).get()).toArray<SgVendor>()
         : [];
     const vendorMap = new Map(vendorList.map(vendor => [vendor.id, vendor]));
 

--- a/src/service/modelService.ts
+++ b/src/service/modelService.ts
@@ -18,6 +18,34 @@ async function getModel(modelName: string, enable?: boolean): Promise<SgModel | 
 }
 
 
+async function listEnabledModels() {
+    const models = await SgModel.query()
+        .where("enable", 1)
+        .orderBy("id", "asc")
+        .get();
+    const modelList = models.toArray();
+    const vendorIds = [...new Set(modelList.map(model => model.vendor_id as number))];
+    const vendorList = vendorIds.length > 0
+        ? (await SgVendor.query().whereIn("id", vendorIds).get()).toArray()
+        : [];
+    const vendorMap = new Map(vendorList.map(vendor => [vendor.id, vendor]));
+
+    return modelList.map(model => {
+        const vendor = vendorMap.get(model.vendor_id!);
+        if (!vendor) {
+            throw new customError.AppError(`Vendor not found for model ${model.name}`, 500);
+        }
+
+        return {
+            id: model.name,
+            object: "model",
+            created: Math.floor(new Date(model.created_at).getTime() / 1000),
+            owned_by: vendor.name,
+        };
+    });
+}
+
+
 async function checkDuplicateEnabledModel(
     name: string,
     excludeId?: number,
@@ -86,5 +114,6 @@ async function updateModel(
 
 export default {
     getModel,
+    listEnabledModels,
     updateModel,
 };

--- a/tests/api/ai/models.negative.test.ts
+++ b/tests/api/ai/models.negative.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import requestHelper from "../../helpers/requestHelper";
+import dbHelper from "../../helpers/dbHelper";
+import { setupAdminUser } from "../../globalSetup";
+
+const adminToken = "admin-token-123";
+const disabledToken = "disabled-models-user-token";
+
+describe("GET /llm/v1/models authentication", () => {
+    beforeAll(async () => {
+        await dbHelper.truncate();
+        await setupAdminUser();
+
+        const user = await requestHelper.post(
+            "/user/create.json",
+            { name: "Disabled Models User", token: disabledToken, type: "normal" },
+            adminToken,
+        );
+        await requestHelper.put(
+            `/user/${user.body.id}`,
+            { status: "disabled" },
+            adminToken,
+        );
+    });
+
+    it("rejects a request without authentication", async () => {
+        const response = await requestHelper.get("/llm/v1/models");
+
+        expect(response.status).toBe(401);
+        expect(response.body.error.type).toBe("authentication_error");
+    });
+
+    it("rejects an invalid token", async () => {
+        const response = await requestHelper.get("/llm/v1/models", "invalid-token");
+
+        expect(response.status).toBe(401);
+        expect(response.body.error.message).toContain("Invalid token");
+    });
+
+    it("rejects a disabled user", async () => {
+        const response = await requestHelper.get("/llm/v1/models", disabledToken);
+
+        expect(response.status).toBe(403);
+        expect(response.body.error.message).toBe("User disabled");
+    });
+});

--- a/tests/api/ai/models.test.ts
+++ b/tests/api/ai/models.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import requestHelper from "../../helpers/requestHelper";
+import dbHelper from "../../helpers/dbHelper";
+import { setupAdminUser } from "../../globalSetup";
+
+const adminToken = "admin-token-123";
+const normalToken = "models-user-token";
+
+describe("GET /llm/v1/models", () => {
+    beforeAll(async () => {
+        await dbHelper.truncate();
+        await setupAdminUser();
+
+        await requestHelper.post(
+            "/user/create.json",
+            { name: "Models User", token: normalToken, type: "normal" },
+            adminToken,
+        );
+
+        const openaiVendor = await requestHelper.post(
+            "/vendor/create.json",
+            {
+                type: "other",
+                name: "openai",
+                token: "openai-token",
+                urls: { openai: "https://api.openai.com/v1/chat/completions" },
+            },
+            adminToken,
+        );
+        const anthropicVendor = await requestHelper.post(
+            "/vendor/create.json",
+            {
+                type: "other",
+                name: "anthropic",
+                token: "anthropic-token",
+                urls: { anthropic: "https://api.anthropic.com/v1/messages" },
+            },
+            adminToken,
+        );
+
+        await requestHelper.post(
+            "/model/create.json",
+            { name: "gpt-4o", vendor_id: openaiVendor.body.id, enable: true },
+            adminToken,
+        );
+        await requestHelper.post(
+            "/model/create.json",
+            { name: "claude-sonnet-4-5", vendor_id: anthropicVendor.body.id, enable: true },
+            adminToken,
+        );
+        await requestHelper.post(
+            "/model/create.json",
+            { name: "disabled-model", vendor_id: openaiVendor.body.id, enable: false },
+            adminToken,
+        );
+    });
+
+    it("returns enabled models in OpenAI format with Bearer authentication", async () => {
+        const response = await requestHelper.get("/llm/v1/models", normalToken);
+
+        expect(response.status).toBe(200);
+        expect(response.body.object).toBe("list");
+        expect(response.body.data).toHaveLength(2);
+        expect(response.body.data).toEqual([
+            {
+                id: "gpt-4o",
+                object: "model",
+                created: expect.any(Number),
+                owned_by: "openai",
+            },
+            {
+                id: "claude-sonnet-4-5",
+                object: "model",
+                created: expect.any(Number),
+                owned_by: "anthropic",
+            },
+        ]);
+        expect(response.body.data.every((model: { created: number }) => (
+            Number.isInteger(model.created) && model.created > 0
+        ))).toBe(true);
+    });
+
+    it("accepts x-api-key authentication", async () => {
+        const response = await requestHelper.request("/llm/v1/models", {
+            method: "GET",
+            headers: { "x-api-key": normalToken },
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.body.data.map((model: { id: string }) => model.id)).not.toContain("disabled-model");
+    });
+
+    it("allows x-api-key in browser CORS preflight requests", async () => {
+        const response = await requestHelper.request("/llm/v1/models", {
+            method: "OPTIONS",
+            headers: {
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-api-key",
+            },
+        });
+
+        expect(response.status).toBe(204);
+        expect(response.headers.get("access-control-allow-headers")).toContain("x-api-key");
+    });
+});


### PR DESCRIPTION
## 概述

新增 OpenAI 兼容的 `GET /llm/v1/models` 端点，让 OpenAI SDK、前端 AI 客户端、VS Code 插件及各类 Agent 工具可以自动发现网关中的可用模型。

Closes https://github.com/alexazhou/gt_ai_gateway/issues/12

## 主要改动

- 新增 `GET /llm/v1/models` 路由
- 返回标准 OpenAI 模型列表格式
- 支持以下鉴权方式：
  - `Authorization: Bearer <token>`
  - `x-api-key: <token>`
- 校验用户是否存在以及是否处于启用状态
- 仅返回 `enable = 1` 的模型
- 使用关联 vendor 的名称作为 `owned_by`
- 将模型创建时间转换为 Unix 秒时间戳
- 在 CORS 配置中放行 `x-api-key`
- 更新 LLM API 使用文档

响应示例：

```json
{
  "object": "list",
  "data": [
    {
      "id": "gpt-4o",
      "object": "model",
      "created": 1783908000,
      "owned_by": "openai"
    }
  ]
}
```

## 测试

新增 API 测试覆盖：

- Bearer Token 鉴权
- `x-api-key` 鉴权
- OpenAI 标准响应结构
- 禁用模型过滤
- 缺失或无效凭证
- 禁用用户
- `x-api-key` CORS 预检

验证结果：

- 新增测试：6 个用例全部通过
- 前端生产构建通过
- Node 全量测试中，本次新增 models 测试全部通过；仓库现有 accumulator fixture 测试仍有 5 项与本次改动无关的失败