### PR TITLE
feat(model): add model deletion

### DIFF
--- a/doc/design/frontend/Frontend_Product_Documentation.md
+++ b/doc/design/frontend/Frontend_Product_Documentation.md
@@ -197,6 +197,7 @@ Serverless AI Gateway 是一个轻量级的 AI 服务网关，用于统一管理
 - `POST /model/create.json` - 创建模型
 - `GET /model/:id` - 获取模型详情
 - `PUT /model/:id` - 更新模型
+- `DELETE /model/:id` - 删除模型
 
 #### 达到的效果
 - 简洁的模型管理流程

--- a/doc/design/frontend/v1/technical_design.md
+++ b/doc/design/frontend/v1/technical_design.md
@@ -170,7 +170,7 @@ frontend/
 | `getModel` | GET | /model/{id} | id: number | Model |
 | `createModel` | POST | /model/create.json | data: CreateModelRequest | Model |
 | `updateModel` | PUT | /model/{id} | id: number, data: UpdateModelRequest | Model |
-| `deleteModel` | DELETE | /model/{id} | id: number | void |
+| `deleteModel` | DELETE | /model/{id} | id: number | { success: boolean } |
 
 ### 4.5 系统 API 模块（src/api/system.ts）
 

--- a/frontend/src/api/model.ts
+++ b/frontend/src/api/model.ts
@@ -22,3 +22,7 @@ export async function createModel(data: CreateModelRequest): Promise<Model> {
 export async function updateModel(id: number, data: UpdateModelRequest): Promise<Model> {
     return request.put(`/model/${id}`, data);
 }
+
+export async function deleteModel(id: number): Promise<{ success: boolean }> {
+    return request.delete(`/model/${id}`);
+}

--- a/frontend/src/views/Model/List.vue
+++ b/frontend/src/views/Model/List.vue
@@ -92,6 +92,9 @@
                         <a-button type="link" style="padding: 0" @click="handleTest(record)">
                             测试
                         </a-button>
+                        <a-button type="link" danger style="padding: 0" @click="handleDelete(record)">
+                            删除
+                        </a-button>
                     </a-space>
                 </template>
             </template>
@@ -106,8 +109,9 @@
 import { ref, computed, watch, onMounted } from 'vue';
 import type { TableColumnsType } from 'ant-design-vue';
 import { useRouter } from 'vue-router';
+import { Modal } from 'ant-design-vue/es';
 import { InfoCircleOutlined } from '@ant-design/icons-vue';
-import { listModels } from '@/api/model';
+import { deleteModel, listModels } from '@/api/model';
 import { listVendors, fetchVendorModelsByIds } from '@/api/vendor';
 import { getConfig } from '@/api/config';
 import { useResourceTable } from '@/composables/useResourceTable';
@@ -117,6 +121,7 @@ import DialogForm from './DialogForm.vue';
 import DialogTest from '@/views/Vendor/DialogTest.vue';
 import type { Model, ModelQuery } from '@/types/model';
 import type { Vendor as VendorType, VendorModel } from '@/types/vendor';
+import { notifyRequestError, notifySuccess } from '@/utils/requestFeedback';
 
 const router = useRouter();
 
@@ -153,7 +158,7 @@ const columns = computed<TableColumnsType<Model>>(() => {
     }
     cols.push(
         { title: '创建时间', key: 'created_at', dataIndex: 'created_at' },
-        { title: '操作', key: 'action', width: 120, fixed: 'right' as const },
+        { title: '操作', key: 'action', width: 160, fixed: 'right' as const },
     );
     return cols;
 });
@@ -205,6 +210,25 @@ function handleTest(record: Model) {
         vendorModelName,
         allowedFormats: vendorModel?.allowed_formats ?? null,
         showAutoConvert: true,
+    });
+}
+
+function handleDelete(record: Model) {
+    Modal.confirm({
+        title: '确认删除',
+        content: `确定要删除模型 "${record.name}" 吗？`,
+        okText: '确定',
+        cancelText: '取消',
+        okType: 'danger',
+        onOk: async () => {
+            try {
+                await deleteModel(record.id);
+                notifySuccess('删除成功');
+                void loadData();
+            } catch (error) {
+                notifyRequestError(error, '删除失败');
+            }
+        },
     });
 }
 

--- a/src/controller/modelController.ts
+++ b/src/controller/modelController.ts
@@ -163,9 +163,9 @@ async function updateModel(c: Context) {
 
 async function deleteModel(c: Context) {
     const id = c.req.param("id");
-    const modelId = parseInt(id, 10);
+    const modelId = Number(id);
 
-    if (isNaN(modelId)) {
+    if (!Number.isInteger(modelId) || modelId <= 0) {
         throw new customError.AppError("Invalid ID format");
     }
 

--- a/src/controller/modelController.ts
+++ b/src/controller/modelController.ts
@@ -160,6 +160,24 @@ async function updateModel(c: Context) {
     return c.json(updatedModel);
 }
 
+
+async function deleteModel(c: Context) {
+    const id = c.req.param("id");
+    const modelId = parseInt(id, 10);
+
+    if (isNaN(modelId)) {
+        throw new customError.AppError("Invalid ID format");
+    }
+
+    const deleted = await modelService.deleteModel(modelId);
+
+    if (!deleted) {
+        throw new customError.NotFoundError("Model not found");
+    }
+
+    return c.json({ success: true });
+}
+
 export default {
     createModel,
     listModels,
@@ -167,4 +185,5 @@ export default {
     getModel,
     getModelsByIds,
     updateModel,
+    deleteModel,
 };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -141,6 +141,7 @@ app.get("/model/list.json", authMiddleware.requireAdmin, modelController.listMod
 app.post("/model/batch.json", authMiddleware.requireAdmin, modelController.getModelsByIds);
 app.get("/model/:id", authMiddleware.requireAdmin, modelController.getModel);
 app.put("/model/:id", authMiddleware.requireAdmin, modelController.updateModel);
+app.delete("/model/:id", authMiddleware.requireAdmin, modelController.deleteModel);
 
 // User (需要管理员权限)
 app.get("/user/list.json", authMiddleware.requireAdmin, userController.listUsers);

--- a/src/service/modelService.ts
+++ b/src/service/modelService.ts
@@ -112,8 +112,21 @@ async function updateModel(
     return await SgModel.query().find(modelId);
 }
 
+
+async function deleteModel(modelId: number): Promise<boolean> {
+    const model = await SgModel.query().find(modelId);
+
+    if (!model) {
+        return false;
+    }
+
+    await SgModel.query().where("id", modelId).delete();
+    return true;
+}
+
 export default {
     getModel,
     listEnabledModels,
     updateModel,
+    deleteModel,
 };

--- a/tests/api/model/model.negative.test.ts
+++ b/tests/api/model/model.negative.test.ts
@@ -189,5 +189,16 @@ describe("Model API (Negative)", () => {
             expect(response.status).toBe(400);
             expect(response.body.error).toBe("Invalid ID format");
         });
+
+        it("should reject malformed numeric IDs without deleting the matching model", async () => {
+            const response = await requestHelper.del(`/model/${existingModelId}abc`, adminToken);
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe("Invalid ID format");
+
+            const modelResponse = await requestHelper.get(`/model/${existingModelId}`, adminToken);
+            expect(modelResponse.status).toBe(200);
+            expect(modelResponse.body.name).toBe(existingModelName);
+        });
     });
 });

--- a/tests/api/model/model.negative.test.ts
+++ b/tests/api/model/model.negative.test.ts
@@ -174,4 +174,20 @@ describe("Model API (Negative)", () => {
             expect(response.body).toHaveProperty("error");
         });
     });
+
+    describe("DELETE /model/:id", () => {
+        it("should return 404 for non-existent model ID", async () => {
+            const response = await requestHelper.del("/model/99999", adminToken);
+
+            expect(response.status).toBe(404);
+            expect(response.body.error).toBe("Model not found");
+        });
+
+        it("should return error for invalid ID format", async () => {
+            const response = await requestHelper.del("/model/invalid-id", adminToken);
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toBe("Invalid ID format");
+        });
+    });
 });

--- a/tests/api/model/model.test.ts
+++ b/tests/api/model/model.test.ts
@@ -464,4 +464,35 @@ describe("Model API (Positive)", () => {
             expect(response.body.vendor_model_id).toBeNull();
         });
     });
+
+    describe("DELETE /model/:id", () => {
+        it("should delete a model and allow its vendor to be deleted", async () => {
+            const vendorResponse = await requestHelper.post(
+                "/vendor/create.json",
+                vendorFixtures.createRandomVendor({ name: "Model Deletion Vendor" }),
+                adminToken,
+            );
+            const vendorId = vendorResponse.body.id;
+            const modelResponse = await requestHelper.post(
+                "/model/create.json",
+                modelFixtures.createRandomModel(vendorId, "model-to-delete"),
+                adminToken,
+            );
+            const modelId = modelResponse.body.id;
+
+            const blockedVendorDelete = await requestHelper.del(`/vendor/${vendorId}`, adminToken);
+            expect(blockedVendorDelete.status).toBe(400);
+
+            const deleteResponse = await requestHelper.del(`/model/${modelId}`, adminToken);
+            expect(deleteResponse.status).toBe(200);
+            expect(deleteResponse.body).toEqual({ success: true });
+
+            const getResponse = await requestHelper.get(`/model/${modelId}`, adminToken);
+            expect(getResponse.status).toBe(404);
+
+            const vendorDeleteResponse = await requestHelper.del(`/vendor/${vendorId}`, adminToken);
+            expect(vendorDeleteResponse.status).toBe(200);
+            expect(vendorDeleteResponse.body).toEqual({ success: true });
+        });
+    });
 });


### PR DESCRIPTION
## 变更说明

补充平台模型删除功能，解决供应商存在关联模型时无法完成删除的问题。

此前删除供应商会提示：

```text
Cannot delete vendor with associated models
```

但模型管理页没有删除入口，后端也没有对应接口，导致用户无法解除供应商与平台模型之间的关联阻塞。

## 主要改动

- 新增后端接口 `DELETE /model/:id`
- 模型不存在时返回 404
- 模型管理页操作列新增“删除”按钮
- 删除前显示包含模型名称的二次确认
- 删除成功后自动刷新模型列表
- 删除失败时显示错误提示
- 补充模型删除相关 API 测试
- 更新相关前端设计文档

删除关联的平台模型后，用户可以继续删除对应供应商。删除模型不会级联清除历史请求记录。

## 验证结果

- 模型 API 正向和负向测试：41 个用例全部通过
- 前端生产构建通过
- 完整 Node 测试已执行，存在 6 个与本次修改无关的既有失败：
  - 5 个 accumulator fixture 测试
  - 1 个前端静态资源测试

Closes #15
